### PR TITLE
feat: 주식 가격 차트 및 테이블 UI 개선 및 인터랙션 기능 추가

### DIFF
--- a/src/api/stockApi.js
+++ b/src/api/stockApi.js
@@ -28,6 +28,9 @@ const stockApi = {
 
   // 9. 주가 정보 가져오기
   getStockPrice: (code) => publicApi.get(`/stock/${code}/price`),
+
+    // 10. 티커별 가격 히스토리 조회
+    getStockPriceHistory: (code) => publicApi.get(`/stock/${code}/history`),
 }
 
 export default stockApi

--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -1,0 +1,51 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  Title,
+  Tooltip,
+  Legend,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+} from 'chart.js'
+import zoomPlugin from 'chartjs-plugin-zoom'
+
+ChartJS.register(Title, Tooltip, Legend, LineElement, PointElement, CategoryScale, LinearScale, zoomPlugin, BarElement)
+
+defineProps({
+  chartData: Object,
+})
+
+const chartOptions = {
+  responsive: true,
+  plugins: {
+    legend: { position: 'top' },
+    zoom: {
+      pan: {
+        enabled: true,
+        mode: 'x',
+      },
+      zoom: {
+        wheel: {
+          enabled: true,
+        },
+        pinch: {
+          enabled: true,
+        },
+        mode: 'x',
+      },
+    },
+  },
+}
+</script>
+
+<template>
+  <Line
+    :data="chartData"
+    :options="chartOptions"
+  />
+</template>
+

--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -12,12 +12,17 @@ import {
   BarElement,
 } from 'chart.js'
 import zoomPlugin from 'chartjs-plugin-zoom'
+import { ref } from 'vue'
 
 ChartJS.register(Title, Tooltip, Legend, LineElement, PointElement, CategoryScale, LinearScale, zoomPlugin, BarElement)
+
+const emit = defineEmits(['point-click'])
 
 defineProps({
   chartData: Object,
 })
+
+const chartRef = ref(null)
 
 const chartOptions = {
   responsive: true,
@@ -39,11 +44,40 @@ const chartOptions = {
       },
     },
   },
+  scales: {
+    y: {
+      display: true,
+      position: 'left',
+      grid: { drawOnChartArea: true },
+      ticks: {
+        color: '#a0aec0',
+        font: { size: 12 },
+      },
+    },
+    y2: {
+      display: false,
+      position: 'right',
+      grid: { drawOnChartArea: false },
+      min: 0,
+      max: (ctx) => {
+        const max = ctx.chart.data.datasets[1]?.data?.reduce((a, b) => Math.max(a, b), 0) || 100
+        return max * 8
+      },
+    },
+  },
+  onClick: (e, elements, chart) => {
+    if (elements.length > 0) {
+      const idx = elements[0].index
+      const date = chart.data.labels[idx]
+      emit('point-click', date)
+    }
+  },
 }
 </script>
 
 <template>
   <Line
+    ref="chartRef"
     :data="chartData"
     :options="chartOptions"
   />

--- a/src/components/StockRealtimeChart.vue
+++ b/src/components/StockRealtimeChart.vue
@@ -137,14 +137,14 @@ export default {
   data() {
     return {
       currentTime: '',
-      activeTab: 'volume-rank',
+      activeTab: 'market-cap-rank',
       activePeriod: '1일',
       tabs: [
+        { id: 'market-cap-rank', name: '시가총액' },
         { id: 'volume-rank', name: '거래량' },
         { id: 'trading-value-rank', name: '거래대금' },
         { id: 'price-up-rank', name: '급상승' },
         { id: 'price-down-rank', name: '급하락' },
-        { id: 'market-cap-rank', name: '시가총액' }
       ],
       timePeriods: ['1일', '1주일', '1개월', '3개월', '6개월', '1년'],
       stockData: [],

--- a/src/components/StockTabNav.vue
+++ b/src/components/StockTabNav.vue
@@ -7,6 +7,12 @@
       >가격/호가</router-link
     >
     <router-link
+      :to="`/stock/${stockId}/history`"
+      class="tab-btn"
+      :class="{ active: isActive('history') }"
+      >가격추이</router-link
+    >
+    <router-link
       :to="`/stock/${stockId}/stock-info`"
       class="tab-btn"
       :class="{ active: isActive('stock-info') }"
@@ -32,6 +38,9 @@ function isActive(tab) {
 
   if (tab === 'price') {
     return path.includes('/price')
+  }
+  if (tab === 'history') {
+    return path.includes('/history')
   }
   if (tab === 'stock-info') {
     return path.includes('/stock-info')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,7 @@ import FinancialRatioView from '@/views/StockInfo/FinancialRatioView.vue'
 import ProfitRatioView from '@/views/StockInfo/ProfitRatioView.vue'
 import StabilityRatioView from '@/views/StockInfo/StabilityRatioView.vue'
 import GrowthRatioView from '@/views/StockInfo/GrowthRatioView.vue'
+import StockPriceHistoryView from '@/views/StockInfo/StockPriceHistoryView.vue'
 
 import LoginView from '@/views/user/LoginView.vue'
 import SignupView from '@/views/user/SignupView.vue'
@@ -129,6 +130,11 @@ const router = createRouter({
           path: 'community',
           name: 'community',
           component: PostView,
+        },
+        {
+          path: 'history',
+          name: 'stockPriceHistory',
+          component: StockPriceHistoryView,
         },
       ],
     },

--- a/src/views/StockInfo/StockPriceHistoryView.vue
+++ b/src/views/StockInfo/StockPriceHistoryView.vue
@@ -8,7 +8,6 @@
     <div v-else-if="error" style="color:red">{{ error }}</div>
     <div v-else>
       <LineChart :chartData="chartData" style="width:100%;max-width:1200px;height:400px;margin:0 auto 32px;" @point-click="onChartPointClick" />
-      <!-- <BarChart :chartData="chartDataVolume" style="width:100%;max-width:1200px;height:180px;margin:0 auto 24px;" /> -->
       <div class="table-scroll-wrap" ref="tableWrapRef" @scroll="onTableScroll">
         <table>
           <thead>
@@ -27,8 +26,8 @@
               <td>{{ item.openPrice }}</td>
               <td>{{ item.highPrice }}</td>
               <td>{{ item.lowPrice }}</td>
-              <td>{{ item.closePrice }}</td>
-              <td>{{ item.volume }}</td>
+              <td @click="onTableCellClick(item.tradeDate)" style="cursor:pointer;">{{ item.closePrice }}</td>
+              <td @click="onTableCellClick(item.tradeDate)" style="cursor:pointer;">{{ item.volume }}</td>
             </tr>
           </tbody>
         </table>
@@ -44,7 +43,6 @@ import { ref, onMounted, computed, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import stockApi from '@/api/stockApi'
 import LineChart from '@/components/LineChart.vue'
-import BarChart from '@/components/BarChart.vue'
 
 const route = useRoute()
 const stockId = route.params.stockId
@@ -90,24 +88,6 @@ const chartData = computed(() => {
       },
     ],
     y2Max: maxVolume * 8,
-  }
-})
-
-const chartDataVolume = computed(() => {
-  const arr = [...history.value].reverse()
-  return {
-    labels: arr.map(item => item.tradeDate),
-    datasets: [
-      {
-        label: '거래량',
-        data: arr.map(item => item.volume),
-        backgroundColor: 'rgba(139, 92, 246, 0.4)',
-        borderColor: 'rgba(139, 92, 246, 1)',
-        borderWidth: 1,
-        barPercentage: 0.7,
-        categoryPercentage: 0.7,
-      },
-    ],
   }
 })
 
@@ -169,6 +149,11 @@ async function scrollToDate() {
 }
 
 function onChartPointClick(date) {
+  searchDate.value = date
+  scrollToDate()
+}
+
+function onTableCellClick(date) {
   searchDate.value = date
   scrollToDate()
 }

--- a/src/views/StockInfo/StockPriceHistoryView.vue
+++ b/src/views/StockInfo/StockPriceHistoryView.vue
@@ -1,0 +1,244 @@
+<template>
+  <div class="stock-price-history-view">
+    <h2>가격 히스토리: {{ stockId }}</h2>
+    <div class="date-search-wrap">
+      <span v-if="notFoundMsg" class="not-found-msg">{{ notFoundMsg }}</span>
+    </div>
+    <div v-if="loading">불러오는 중...</div>
+    <div v-else-if="error" style="color:red">{{ error }}</div>
+    <div v-else>
+      <LineChart :chartData="chartData" style="width:100%;max-width:1200px;height:400px;margin:0 auto 32px;" @point-click="onChartPointClick" />
+      <!-- <BarChart :chartData="chartDataVolume" style="width:100%;max-width:1200px;height:180px;margin:0 auto 24px;" /> -->
+      <div class="table-scroll-wrap" ref="tableWrapRef" @scroll="onTableScroll">
+        <table>
+          <thead>
+            <tr>
+              <th>날짜</th>
+              <th>시가</th>
+              <th>고가</th>
+              <th>저가</th>
+              <th>종가</th>
+              <th>거래량</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in visibleHistory" :key="item.id || item.date" :data-date="item.tradeDate">
+              <td>{{ item.tradeDate }}</td>
+              <td>{{ item.openPrice }}</td>
+              <td>{{ item.highPrice }}</td>
+              <td>{{ item.lowPrice }}</td>
+              <td>{{ item.closePrice }}</td>
+              <td>{{ item.volume }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <div v-if="tableLoading" style="text-align:center;padding:8px;">불러오는 중...</div>
+        <div v-if="visibleHistory.length === 0 && !loading">데이터가 없습니다.</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+import stockApi from '@/api/stockApi'
+import LineChart from '@/components/LineChart.vue'
+import BarChart from '@/components/BarChart.vue'
+
+const route = useRoute()
+const stockId = route.params.stockId
+const history = ref([])
+const loading = ref(true)
+const error = ref('')
+const page = ref(1)
+const pageSize = 20
+const visibleHistory = ref([])
+const tableLoading = ref(false)
+const searchDate = ref('')
+const tableWrapRef = ref(null)
+const notFoundMsg = ref('')
+const scrolling = ref(false)
+
+const chartData = computed(() => {
+  const arr = [...history.value].reverse()
+  const maxVolume = Math.max(...arr.map(item => item.volume))
+  return {
+    labels: arr.map(item => item.tradeDate),
+    datasets: [
+      {
+        label: '종가',
+        data: arr.map(item => item.closePrice),
+        borderColor: 'rgba(75, 192, 192, 1)',
+        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+        tension: 0.2,
+        fill: false,
+        yAxisID: 'y',
+        type: 'line',
+      },
+      {
+        label: '거래량',
+        data: arr.map(item => item.volume),
+        backgroundColor: 'rgba(139, 92, 246, 0.18)',
+        borderColor: 'rgba(139, 92, 246, 0.3)',
+        yAxisID: 'y2',
+        type: 'bar',
+        order: 2,
+        barPercentage: 0.4,
+        categoryPercentage: 0.4,
+        barThickness: 6,
+      },
+    ],
+    y2Max: maxVolume * 8,
+  }
+})
+
+const chartDataVolume = computed(() => {
+  const arr = [...history.value].reverse()
+  return {
+    labels: arr.map(item => item.tradeDate),
+    datasets: [
+      {
+        label: '거래량',
+        data: arr.map(item => item.volume),
+        backgroundColor: 'rgba(139, 92, 246, 0.4)',
+        borderColor: 'rgba(139, 92, 246, 1)',
+        borderWidth: 1,
+        barPercentage: 0.7,
+        categoryPercentage: 0.7,
+      },
+    ],
+  }
+})
+
+onMounted(async () => {
+  try {
+    const res = await stockApi.getStockPriceHistory(stockId)
+    history.value = res.data
+    visibleHistory.value = history.value.slice(0, pageSize)
+  } catch {
+    error.value = '가격 히스토리 데이터를 불러오지 못했습니다.'
+  } finally {
+    loading.value = false
+  }
+})
+
+function loadMore() {
+  if (tableLoading.value) return
+  tableLoading.value = true
+  setTimeout(() => {
+    const next = page.value * pageSize
+    visibleHistory.value = history.value.slice(0, next + pageSize)
+    page.value++
+    tableLoading.value = false
+  }, 300)
+}
+
+function onTableScroll(e) {
+  const el = e.target
+  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+    loadMore()
+  }
+}
+
+async function scrollToDate() {
+  notFoundMsg.value = ''
+  if (!searchDate.value) return
+  if (scrolling.value) return
+  scrolling.value = true
+  // 최신순(내림차순)에서 해당 날짜의 인덱스 찾기
+  const idx = history.value.findIndex(item => item.tradeDate === searchDate.value)
+  if (idx === -1) {
+    notFoundMsg.value = '해당 날짜 데이터가 없습니다.'
+    scrolling.value = false
+    return
+  }
+  // visibleHistory에 없으면 한 번에 확장
+  if (idx >= visibleHistory.value.length) {
+    const newLen = Math.ceil((idx + 1) / pageSize) * pageSize
+    visibleHistory.value = history.value.slice(0, newLen)
+    page.value = Math.ceil(newLen / pageSize)
+    await nextTick()
+  }
+  // 테이블에서 해당 행으로 스크롤
+  const row = tableWrapRef.value.querySelector(`tr[data-date='${searchDate.value}']`)
+  if (row) {
+    row.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+  scrolling.value = false
+}
+
+function onChartPointClick(date) {
+  searchDate.value = date
+  scrollToDate()
+}
+</script>
+
+<style scoped>
+.table-scroll-wrap {
+  max-height: 400px;
+  overflow-y: auto;
+  margin-bottom: 16px;
+  border-radius: 10px;
+  border: 1px solid #23263a;
+  background: #181c2f;
+  box-shadow: 0 2px 12px rgba(24,28,47,0.08);
+}
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: #181c2f;
+  color: #f3f6fa;
+  font-size: 1rem;
+}
+th, td {
+  padding: 10px 8px;
+  text-align: center;
+}
+th {
+  background: linear-gradient(90deg, #23263a 60%, #23263a 100%);
+  color: #a0aec0;
+  font-weight: 700;
+  border-bottom: 2px solid #23263a;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+td {
+  border-bottom: 1px solid #23263a;
+  color: #f3f6fa;
+}
+tr {
+  transition: background 0.15s;
+}
+tbody tr:hover {
+  background: #23263a;
+}
+.table-scroll-wrap::-webkit-scrollbar {
+  width: 8px;
+  background: #23263a;
+}
+.table-scroll-wrap::-webkit-scrollbar-thumb {
+  background: #374151;
+  border-radius: 8px;
+}
+.date-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.date-search-wrap input[type="date"] {
+  background: #23263a;
+  color: #f3f6fa;
+  border: 1px solid #374151;
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+.not-found-msg {
+  color: #ff7675;
+  margin-left: 8px;
+  font-size: 0.98rem;
+}
+</style>

--- a/src/views/post/PostView.vue
+++ b/src/views/post/PostView.vue
@@ -235,6 +235,7 @@ function formatDate(dateString) {
   })
 }
 
+// 현재 주가 가져오기
 async function fetchStockInfo() {
   try {
     const res = await stockApi.getStockInfo(stockId)


### PR DESCRIPTION
## 개요 
- 주식 가격 시각화 화면(차트 + 테이블)의 기능 개선 및 UI 정보를 보완했습니다.
- 사용자 인터랙션 중심 기능(차트 → 테이블 이동)과 정보 우선순위 정렬을 추가했습니다.

---

## 주요 변경 사항 
1. **차트 클릭 시 해당 시점의 테이블로 스크롤 이동** 기능 
2. **거래량 데이터 단위/표시 방식 수정**
3. 주식 이름, 현재가, 전일대비 등 **기본 가격정보 상단에 표시**
4. **시가총액 기준 종목 랭킹**을 우선 표시하도록 정렬 방식 개선

---

## 개선 효과 
- 사용자 입장에서 **차트 ↔ 테이블 데이터 연동성** 강화
- 가격 및 종목 정보 확인이 **더 직관적이고 빠름**
- 초기 진입 시 **관심 종목 우선 노출 (시총 순)**로 UX 향상

---

## 기타 참고 사항 
- 서버 실행 전 npm install chartjs-plugin-zoom 명령어로 의존성 관리 필요 
